### PR TITLE
System.Reflection.Metadata: migrate XML docs (fill-gaps)

### DIFF
--- a/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/AssemblyNameInfo.cs
+++ b/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/AssemblyNameInfo.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
@@ -49,6 +49,16 @@ namespace System.Reflection.Metadata
         }
 #endif
 
+        /// <summary>
+        /// Initializes a new instance of the AssemblyNameInfo class.
+        /// </summary>
+        /// <param name="name">The simple name of the assembly.</param>
+        /// <param name="version">The version of the assembly.</param>
+        /// <param name="cultureName">The name of the culture associated with the assembly.</param>
+        /// <param name="flags">The attributes of the assembly.</param>
+        /// <param name="publicKeyOrToken">The public key or its token. Set <paramref name="flags"/> to <see cref="AssemblyNameFlags.PublicKey"/> when it's public key.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="name"/> is null.</exception>
+        /// <exception cref="T:System.ArgumentNullException"><paramref name="name"/> is <see langword="null"/>.</exception>
         internal AssemblyNameInfo(AssemblyNameParser.AssemblyNameParts parts)
         {
             Name = parts._name;

--- a/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/BlobBuilder.cs
+++ b/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/BlobBuilder.cs
@@ -52,6 +52,7 @@ namespace System.Reflection.Metadata
         private uint FrozenLength => _length | IsFrozenMask;
         private Span<byte> Span => _buffer.AsSpan(0, Length);
 
+        /// <param name="capacity">To be added.</param>
         public BlobBuilder(int capacity = DefaultChunkSize)
         {
             if (capacity < 0)
@@ -63,6 +64,7 @@ namespace System.Reflection.Metadata
             _buffer = new byte[Math.Max(MinChunkSize, capacity)];
         }
 
+        /// <param name="minimalSize">To be added.</param>
         protected virtual BlobBuilder AllocateChunk(int minimalSize)
         {
             return new BlobBuilder(Math.Max(_buffer.Length, minimalSize));
@@ -789,6 +791,15 @@ namespace System.Reflection.Metadata
             WriteBytes(buffer.AsSpan(start, byteCount));
         }
 
+        /// <summary>
+        /// Writes a specified number of occurrences of a byte value to the builder.
+        /// </summary>
+        /// <param name="value">To be added.</param>
+        /// <param name="byteCount">The number of occurences of <paramref name="value"/> to write.</param>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="byteCount"/> is negative.</exception>
+        /// <exception cref="InvalidOperationException">Builder is not writable, it has been linked with another one.</exception>
+        /// <exception cref="T:System.ArgumentOutOfRangeException"><paramref name="byteCount"/> is negative.</exception>
+        /// <exception cref="T:System.InvalidOperationException">The builder is not writable, it has been linked with another one.</exception>
         internal void WriteBytes(ReadOnlySpan<byte> buffer)
         {
             if (!IsHead)
@@ -991,6 +1002,14 @@ namespace System.Reflection.Metadata
             WriteUTF16(value.AsSpan());
         }
 
+        /// <summary>
+        /// Writes UTF-16 (little-endian) encoded string at the current position.
+        /// </summary>
+        /// <param name="value">To be added.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="value"/> is null.</exception>
+        /// <exception cref="InvalidOperationException">Builder is not writable, it has been linked with another one.</exception>
+        /// <exception cref="T:System.ArgumentNullException"><paramref name="value"/> is <see langword="null"/>.</exception>
+        /// <exception cref="T:System.InvalidOperationException">Builder is not writable, it has been linked with another one.</exception>
         private void WriteUTF16(ReadOnlySpan<char> value)
         {
             if (!IsHead)
@@ -1072,6 +1091,15 @@ namespace System.Reflection.Metadata
             WriteUTF8(value, 0, value.Length, allowUnpairedSurrogates, prependSize: false);
         }
 
+        /// <summary>
+        /// Writes UTF-8 encoded string at the current position.
+        /// </summary>
+        /// <param name="value">Constant value.</param>
+        /// <param name="allowUnpairedSurrogates"> True to encode unpaired surrogates as specified, otherwise replace them with U+FFFD character. </param>
+        /// <exception cref="ArgumentNullException"><paramref name="value"/> is null.</exception>
+        /// <exception cref="InvalidOperationException">Builder is not writable, it has been linked with another one.</exception>
+        /// <exception cref="T:System.ArgumentNullException"><paramref name="value"/> is <see langword="null"/>.</exception>
+        /// <exception cref="T:System.InvalidOperationException">Builder is not writable, it has been linked with another one.</exception>
         internal unsafe void WriteUTF8(string str, int start, int length, bool allowUnpairedSurrogates, bool prependSize)
         {
             Debug.Assert(start >= 0);

--- a/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/BlobReader.cs
+++ b/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/BlobReader.cs
@@ -35,6 +35,17 @@ namespace System.Reflection.Metadata
 
         }
 
+        /// <summary>
+        /// Creates a reader of the specified memory block.
+        /// </summary>
+        /// <param name="buffer">Pointer to the start of the memory block.</param>
+        /// <param name="length">Length in bytes of the memory block.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="buffer"/> is null and <paramref name="length"/> is greater than zero.</exception>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="length"/> is negative.</exception>
+        /// <exception cref="PlatformNotSupportedException">The current platform is not little-endian.</exception>
+        /// <exception cref="T:System.ArgumentNullException"><paramref name="buffer"/> is <see langword="null"/> and <paramref name="length"/> is greater than zero.</exception>
+        /// <exception cref="T:System.ArgumentOutOfRangeException"><paramref name="length"/> is negative.</exception>
+        /// <exception cref="T:System.PlatformNotSupportedException">The current platform is not little-endian.</exception>
         internal BlobReader(MemoryBlock block)
         {
             Debug.Assert(block.Length >= 0 && (block.Pointer != null || block.Length == 0));

--- a/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/BlobWriter.cs
+++ b/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/BlobWriter.cs
@@ -20,21 +20,27 @@ namespace System.Reflection.Metadata
         // position in buffer relative to the beginning of the array:
         private int _position;
 
+        /// <param name="size">To be added.</param>
         public BlobWriter(int size)
             : this(new byte[size])
         {
         }
 
+        /// <param name="buffer">To be added.</param>
         public BlobWriter(byte[] buffer)
             : this(buffer, 0, buffer.Length)
         {
         }
 
+        /// <param name="blob">To be added.</param>
         public BlobWriter(Blob blob)
             : this(blob.Buffer, blob.Start, blob.Length)
         {
         }
 
+        /// <param name="buffer">To be added.</param>
+        /// <param name="start">To be added.</param>
+        /// <param name="count">To be added.</param>
         public BlobWriter(byte[] buffer, int start, int count)
         {
             Debug.Assert(buffer != null);
@@ -147,6 +153,10 @@ namespace System.Reflection.Metadata
             WriteBytes(new ReadOnlySpan<byte>(buffer, byteCount));
         }
 
+        /// <param name="value">To be added.</param>
+        /// <param name="byteCount">To be added.</param>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="byteCount"/> is negative.</exception>
+        /// <exception cref="T:System.ArgumentOutOfRangeException"><paramref name="byteCount"/> is negative.</exception>
         internal void WriteBytes(ReadOnlySpan<byte> buffer)
         {
             int start = Advance(buffer.Length);
@@ -234,112 +244,132 @@ namespace System.Reflection.Metadata
             WriteBytes(buffer.AsSpan(start, byteCount));
         }
 
+        /// <param name="offset">To be added.</param>
         public void PadTo(int offset)
         {
             WriteBytes(0, offset - Offset);
         }
 
+        /// <param name="alignment">To be added.</param>
         public void Align(int alignment)
         {
             int offset = Offset;
             WriteBytes(0, BitArithmetic.Align(offset, alignment) - offset);
         }
 
+        /// <param name="value">To be added.</param>
         public void WriteBoolean(bool value)
         {
             WriteByte((byte)(value ? 1 : 0));
         }
 
+        /// <param name="value">To be added.</param>
         public void WriteByte(byte value)
         {
             int start = Advance(sizeof(byte));
             _buffer[start] = value;
         }
 
+        /// <param name="value">To be added.</param>
         public void WriteSByte(sbyte value)
         {
             WriteByte(unchecked((byte)value));
         }
 
+        /// <param name="value">To be added.</param>
         public void WriteDouble(double value)
         {
             int start = Advance(sizeof(double));
             _buffer.WriteDouble(start, value);
         }
 
+        /// <param name="value">To be added.</param>
         public void WriteSingle(float value)
         {
             int start = Advance(sizeof(float));
             _buffer.WriteSingle(start, value);
         }
 
+        /// <param name="value">To be added.</param>
         public void WriteInt16(short value)
         {
             WriteUInt16(unchecked((ushort)value));
         }
 
+        /// <param name="value">To be added.</param>
         public void WriteUInt16(ushort value)
         {
             int start = Advance(sizeof(ushort));
             _buffer.WriteUInt16(start, value);
         }
 
+        /// <param name="value">To be added.</param>
         public void WriteInt16BE(short value)
         {
             WriteUInt16BE(unchecked((ushort)value));
         }
 
+        /// <param name="value">To be added.</param>
         public void WriteUInt16BE(ushort value)
         {
             int start = Advance(sizeof(ushort));
             _buffer.WriteUInt16BE(start, value);
         }
 
+        /// <param name="value">To be added.</param>
         public void WriteInt32BE(int value)
         {
             WriteUInt32BE(unchecked((uint)value));
         }
 
+        /// <param name="value">To be added.</param>
         public void WriteUInt32BE(uint value)
         {
             int start = Advance(sizeof(uint));
             _buffer.WriteUInt32BE(start, value);
         }
 
+        /// <param name="value">To be added.</param>
         public void WriteInt32(int value)
         {
             WriteUInt32(unchecked((uint)value));
         }
 
+        /// <param name="value">To be added.</param>
         public void WriteUInt32(uint value)
         {
             int start = Advance(sizeof(uint));
             _buffer.WriteUInt32(start, value);
         }
 
+        /// <param name="value">To be added.</param>
         public void WriteInt64(long value)
         {
             WriteUInt64(unchecked((ulong)value));
         }
 
+        /// <param name="value">To be added.</param>
         public void WriteUInt64(ulong value)
         {
             int start = Advance(sizeof(ulong));
             _buffer.WriteUInt64(start, value);
         }
 
+        /// <param name="value">To be added.</param>
         public void WriteDecimal(decimal value)
         {
             int start = Advance(BlobUtilities.SizeOfSerializedDecimal);
             _buffer.WriteDecimal(start, value);
         }
 
+        /// <param name="value">To be added.</param>
         public void WriteGuid(Guid value)
         {
             int start = Advance(BlobUtilities.SizeOfGuid);
             _buffer.WriteGuid(start, value);
         }
 
+        /// <param name="value">To be added.</param>
         public void WriteDateTime(DateTime value)
         {
             WriteInt64(value.Ticks);
@@ -393,6 +423,12 @@ namespace System.Reflection.Metadata
             WriteUTF16(value.AsSpan());
         }
 
+        /// <summary>
+        /// Writes UTF-16 (little-endian) encoded string at the current position.
+        /// </summary>
+        /// <param name="value">To be added.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="value"/> is null.</exception>
+        /// <exception cref="T:System.ArgumentNullException"><paramref name="value"/> is <see langword="null"/>.</exception>
         private void WriteUTF16(ReadOnlySpan<char> value)
         {
             if (BitConverter.IsLittleEndian)
@@ -464,6 +500,13 @@ namespace System.Reflection.Metadata
             WriteUTF8(value, 0, value.Length, allowUnpairedSurrogates, prependSize: false);
         }
 
+        /// <summary>
+        /// Writes UTF-8 encoded string at the current position.
+        /// </summary>
+        /// <param name="value">To be added.</param>
+        /// <param name="allowUnpairedSurrogates">To be added.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="value"/> is null.</exception>
+        /// <exception cref="T:System.ArgumentNullException"><paramref name="value"/> is <see langword="null"/>.</exception>
         private unsafe void WriteUTF8(string str, int start, int length, bool allowUnpairedSurrogates, bool prependSize)
         {
             fixed (char* strPtr = str)

--- a/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/EntityHandle.cs
+++ b/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/EntityHandle.cs
@@ -95,26 +95,44 @@ namespace System.Reflection.Metadata
             }
         }
 
+        /// <summary>
+        /// Returns a value that indicates whether the current instance and the specified object are equal.
+        /// </summary>
+        /// <param name="obj">The object to compare with the current instance.</param>
+        /// <returns><see langword="true"/> if <paramref name="obj"/> is an <see cref="T:System.Reflection.Metadata.EntityHandle"/> and is equal to the current instance; otherwise, <see langword="false"/>.</returns>
         public override bool Equals([NotNullWhen(true)] object? obj)
         {
             return obj is EntityHandle entityHandle && Equals(entityHandle);
         }
 
+        /// <summary>
+        /// Returns a value that indicates whether the current instance and the specified <see cref="T:System.Reflection.Metadata.EntityHandle"/> are equal.
+        /// </summary>
+        /// <param name="other">The value to compare with the current instance.</param>
+        /// <returns><see langword="true"/> if the current instance and <paramref name="other"/> are equal; otherwise, <see langword="false"/>.</returns>
         public bool Equals(EntityHandle other)
         {
             return _vToken == other._vToken;
         }
 
+        /// <summary>
+        /// Returns the hash code for this instance.
+        /// </summary>
+        /// <returns>The hash code for this instance.</returns>
         public override int GetHashCode()
         {
             return unchecked((int)_vToken);
         }
 
+        /// <param name="left">To be added.</param>
+        /// <param name="right">To be added.</param>
         public static bool operator ==(EntityHandle left, EntityHandle right)
         {
             return left.Equals(right);
         }
 
+        /// <param name="left">To be added.</param>
+        /// <param name="right">To be added.</param>
         public static bool operator !=(EntityHandle left, EntityHandle right)
         {
             return !left.Equals(right);

--- a/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/Handle.cs
+++ b/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/Handle.cs
@@ -160,11 +160,17 @@ namespace System.Reflection.Metadata
             }
         }
 
+        /// <param name="obj">To be added.</param>
         public override bool Equals([NotNullWhen(true)] object? obj)
         {
             return obj is Handle handle && Equals(handle);
         }
 
+        /// <summary>
+        /// Indicates whether the current object is equal to another object of the same type.
+        /// </summary>
+        /// <param name="other">An object to compare with this object.</param>
+        /// <returns><see langword="true"/> if the current object is equal to the <paramref name="other"/> parameter; otherwise, <see langword="false"/>.</returns>
         public bool Equals(Handle other)
         {
             return _value == other._value && _vType == other._vType;
@@ -175,11 +181,15 @@ namespace System.Reflection.Metadata
             return _value ^ (_vType << 24);
         }
 
+        /// <param name="left">To be added.</param>
+        /// <param name="right">To be added.</param>
         public static bool operator ==(Handle left, Handle right)
         {
             return left.Equals(right);
         }
 
+        /// <param name="left">To be added.</param>
+        /// <param name="right">To be added.</param>
         public static bool operator !=(Handle left, Handle right)
         {
             return !left.Equals(right);

--- a/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/HandleComparer.cs
+++ b/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/HandleComparer.cs
@@ -18,21 +18,43 @@ namespace System.Reflection.Metadata
             get { return s_default; }
         }
 
+        /// <summary>
+        /// Determines whether the specified objects are equal.
+        /// </summary>
+        /// <param name="x">The first object of type <paramref name="T"/> to compare.</param>
+        /// <param name="y">The second object of type <paramref name="T"/> to compare.</param>
+        /// <returns><see langword="true"/> if the specified objects are equal; otherwise, <see langword="false"/>.</returns>
         public bool Equals(Handle x, Handle y)
         {
             return x.Equals(y);
         }
 
+        /// <summary>
+        /// Determines whether the specified objects are equal.
+        /// </summary>
+        /// <param name="x">The first object of type <paramref name="T"/> to compare.</param>
+        /// <param name="y">The second object of type <paramref name="T"/> to compare.</param>
+        /// <returns><see langword="true"/> if the specified objects are equal; otherwise, <see langword="false"/>.</returns>
         public bool Equals(EntityHandle x, EntityHandle y)
         {
             return x.Equals(y);
         }
 
+        /// <summary>
+        /// Returns a hash code for the specified object.
+        /// </summary>
+        /// <param name="obj">The <see cref="T:System.Object"/> for which a hash code is to be returned.</param>
+        /// <returns>A hash code for the specified object.</returns>
         public int GetHashCode(Handle obj)
         {
             return obj.GetHashCode();
         }
 
+        /// <summary>
+        /// Returns a hash code for the specified object.
+        /// </summary>
+        /// <param name="obj">The <see cref="T:System.Object"/> for which a hash code is to be returned.</param>
+        /// <returns>A hash code for the specified object.</returns>
         public int GetHashCode(EntityHandle obj)
         {
             return obj.GetHashCode();

--- a/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/IL/MethodBodyBlock.cs
+++ b/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/IL/MethodBodyBlock.cs
@@ -9,6 +9,15 @@ using System.Runtime.InteropServices;
 
 namespace System.Reflection.Metadata
 {
+    /// <summary>
+    /// Represents the method body in ECMA 335 assembly.
+    /// </summary>
+    /// <remarks>
+    /// The method body contains Common Intermediate Language (CIL) instructions that make up a method and information about its local variables and exception regions. You can use the <see cref="System.Reflection.Metadata.PEReaderExtensions.GetMethodBody"/> method to get a <c>MethodBodyBlock</c> instance for the specified method.
+    /// The format of CIL instructions and metadata is defined by the ECMA-335 specification. For more information, see [Standard ECMA-335 - Common Language Infrastructure (CLI)](https://www.ecma-international.org/publications-and-standards/standards/ecma-335/) on the Ecma International Web site.
+    /// This example shows how to read method bodies for all methods in the specified type definition and display method body information:
+    /// [!code-csharp[](~/snippets/csharp/System.Reflection.Metadata/MethodBodyBlock/MethodBodyBlockSnippets.cs#PrintMethods)]
+    /// </remarks>
     public sealed class MethodBodyBlock
     {
         private readonly MemoryBlock _il;
@@ -44,37 +53,65 @@ namespace System.Reflection.Metadata
             get { return _size; }
         }
 
+        /// <summary>
+        /// Gets the maximum number of items on the evaluation stack for this method.
+        /// </summary>
+        /// <value>The maximum number of items on the evaluation stack.</value>
         public int MaxStack
         {
             get { return _maxStack; }
         }
 
+        /// <summary>
+        /// Gets a value that indicates whether local variables in this method are initialized to default values of their types.
+        /// </summary>
+        /// <value><see langword="true"/> if local variables are initialized; otherwise, <see langword="false"/>.</value>
         public bool LocalVariablesInitialized
         {
             get { return _localVariablesInitialized; }
         }
 
+        /// <summary>
+        /// Gets the handle to the local variables signature.
+        /// </summary>
+        /// <value>The handle to the local variables signature.</value>
         public StandaloneSignatureHandle LocalSignature
         {
             get { return _localSignature; }
         }
 
+        /// <summary>
+        /// Gets the array of exception regions in this method body.
+        /// </summary>
+        /// <value>The array of exception regions.</value>
         public ImmutableArray<ExceptionRegion> ExceptionRegions
         {
             get { return _exceptionRegions; }
         }
 
+        /// <summary>
+        /// Gets the IL bytecode of this method body as a byte array.
+        /// </summary>
+        /// <returns>A byte array with the IL bytecode of this method body.</returns>
         public byte[]? GetILBytes()
         {
             return _il.ToArray();
         }
 
+        /// <summary>
+        /// Gets the IL bytecode of this method body as an immutable array.
+        /// </summary>
+        /// <returns>An immutable byte array with the IL bytecode of this method body.</returns>
         public ImmutableArray<byte> GetILContent()
         {
             byte[]? bytes = GetILBytes();
             return ImmutableCollectionsMarshal.AsImmutableArray(bytes);
         }
 
+        /// <summary>
+        /// Gets a blob reader that reads the IL bytecode of this method body.
+        /// </summary>
+        /// <returns>A blob reader that reads the IL bytecode of this method body.</returns>
         public BlobReader GetILReader()
         {
             return new BlobReader(_il);
@@ -91,6 +128,12 @@ namespace System.Reflection.Metadata
         private const byte SectEHTable = 0x01;
         private const byte SectFatFormat = 0x40;
 
+        /// <summary>
+        /// Creates a new instance of the <see cref="T:System.Reflection.Metadata.MethodBodyBlock"/> class using the specified blob reader.
+        /// </summary>
+        /// <param name="reader">The blob reader to read the method body.</param>
+        /// <returns>A new instance of the <see cref="T:System.Reflection.Metadata.MethodBodyBlock"/> class.</returns>
+        /// <exception cref="T:System.BadImageFormatException"> The method body data in the specified blob reader is invalid.</exception>
         public static MethodBodyBlock Create(BlobReader reader)
         {
             int startOffset = reader.Offset;

--- a/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/MetadataReader.WinMD.cs
+++ b/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/MetadataReader.WinMD.cs
@@ -7,6 +7,16 @@ using System.Runtime.CompilerServices;
 
 namespace System.Reflection.Metadata
 {
+    /// <summary>
+    /// Reads metadata as defined by the ECMA 335 CLI specification.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="System.Reflection.Metadata.MetadataReader"/> reads the contents of tables and heaps from the specified CLI metadata. It operates low-level constructs such as type and method definitions. For a higher level API to inspect the contents of assemblies using reflection constructs, see <see cref="System.Reflection.MetadataLoadContext"/>.
+    /// You can use constructors, such as <see cref="System.Reflection.Metadata.MetadataReader.#ctor(System.Byte,System.Int32)"/>, to create an instance of <see cref="System.Reflection.Metadata.MetadataReader"/> for a given memory location. To read metadata from the Portable Executable assembly file, create <see cref="System.Reflection.PortableExecutable.PEReader"/> and use the <see cref="System.Reflection.Metadata.PEReaderExtensions.GetMetadataReader(System.Reflection.PortableExecutable.PEReader)"/> extension method.
+    /// The format of CLI metadata is defined by the ECMA-335 specification. For more information, see [Standard ECMA-335 - Common Language Infrastructure (CLI)](https://www.ecma-international.org/publications-and-standards/standards/ecma-335/) on the Ecma International Web site.
+    /// This example shows how to create <see cref="System.Reflection.Metadata.MetadataReader"/> for an assembly and read all type definitions from it:
+    /// <code lang="csharp" source="~/snippets/csharp/System.Reflection.Metadata/MetadataReader/MetadataReaderSnippets.cs" id="SnippetMetadataReader" />
+    /// </remarks>
     public partial class MetadataReader
     {
         internal const string ClrPrefix = "<CLR>";

--- a/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/MetadataReader.cs
+++ b/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/MetadataReader.cs
@@ -72,6 +72,14 @@ namespace System.Reflection.Metadata
         {
         }
 
+        /// <summary>
+        /// Creates a metadata reader from the metadata stored at the given memory location.
+        /// </summary>
+        /// <param name="metadata">A pointer to the first byte in a block of metadata.</param>
+        /// <param name="length">The number of bytes in the block.</param>
+        /// <remarks>
+        /// The memory is owned by the caller and it must be kept memory alive and unmodified throughout the lifetime of the <see cref="MetadataReader"/>.
+        /// </remarks>
         internal unsafe MetadataReader(byte* metadata, int length, MetadataReaderOptions options, MetadataStringDecoder? utf8Decoder, object? memoryOwner)
         {
             // Do not throw here when length is 0. We'll throw BadImageFormatException later on, so that the caller doesn't need to
@@ -1058,11 +1066,13 @@ namespace System.Reflection.Metadata
             return new AssemblyDefinition(this);
         }
 
+        /// <param name="handle">To be added.</param>
         public string GetString(StringHandle handle)
         {
             return StringHeap.GetString(handle, UTF8Decoder);
         }
 
+        /// <param name="handle">To be added.</param>
         public string GetString(NamespaceDefinitionHandle handle)
         {
             if (handle.HasFullName)
@@ -1073,11 +1083,13 @@ namespace System.Reflection.Metadata
             return NamespaceCache.GetFullName(handle);
         }
 
+        /// <param name="handle">To be added.</param>
         public byte[] GetBlobBytes(BlobHandle handle)
         {
             return BlobHeap.GetBytes(handle);
         }
 
+        /// <param name="handle">To be added.</param>
         public ImmutableArray<byte> GetBlobContent(BlobHandle handle)
         {
             // TODO: We can skip a copy for virtual blobs.
@@ -1085,21 +1097,25 @@ namespace System.Reflection.Metadata
             return ImmutableCollectionsMarshal.AsImmutableArray(bytes);
         }
 
+        /// <param name="handle">To be added.</param>
         public BlobReader GetBlobReader(BlobHandle handle)
         {
             return BlobHeap.GetBlobReader(handle);
         }
 
+        /// <param name="handle">To be added.</param>
         public BlobReader GetBlobReader(StringHandle handle)
         {
             return StringHeap.GetBlobReader(handle);
         }
 
+        /// <param name="handle">To be added.</param>
         public string GetUserString(UserStringHandle handle)
         {
             return UserStringHeap.GetString(handle);
         }
 
+        /// <param name="handle">To be added.</param>
         public Guid GetGuid(GuidHandle handle)
         {
             return GuidHeap.GetGuid(handle);
@@ -1115,11 +1131,13 @@ namespace System.Reflection.Metadata
             return new ModuleDefinition(this);
         }
 
+        /// <param name="handle">To be added.</param>
         public AssemblyReference GetAssemblyReference(AssemblyReferenceHandle handle)
         {
             return new AssemblyReference(this, handle.Value);
         }
 
+        /// <param name="handle">To be added.</param>
         public TypeDefinition GetTypeDefinition(TypeDefinitionHandle handle)
         {
             // PERF: This code pattern is JIT friendly and results in very efficient code.
@@ -1132,6 +1150,7 @@ namespace System.Reflection.Metadata
             return new NamespaceDefinition(data);
         }
 
+        /// <param name="handle">To be added.</param>
         public NamespaceDefinition GetNamespaceDefinition(NamespaceDefinitionHandle handle)
         {
             NamespaceData data = NamespaceCache.GetNamespaceData(handle);
@@ -1149,6 +1168,7 @@ namespace System.Reflection.Metadata
             return CalculateTypeDefTreatmentAndRowId(handle);
         }
 
+        /// <param name="handle">To be added.</param>
         public TypeReference GetTypeReference(TypeReferenceHandle handle)
         {
             // PERF: This code pattern is JIT friendly and results in very efficient code.
@@ -1166,16 +1186,19 @@ namespace System.Reflection.Metadata
             return CalculateTypeRefTreatmentAndRowId(handle);
         }
 
+        /// <param name="handle">To be added.</param>
         public ExportedType GetExportedType(ExportedTypeHandle handle)
         {
             return new ExportedType(this, handle.RowId);
         }
 
+        /// <param name="handle">To be added.</param>
         public CustomAttributeHandleCollection GetCustomAttributes(EntityHandle handle)
         {
             return new CustomAttributeHandleCollection(this, handle);
         }
 
+        /// <param name="handle">To be added.</param>
         public CustomAttribute GetCustomAttribute(CustomAttributeHandle handle)
         {
             // PERF: This code pattern is JIT friendly and results in very efficient code.
@@ -1193,17 +1216,20 @@ namespace System.Reflection.Metadata
             return TreatmentAndRowId((byte)CustomAttributeTreatment.WinMD, handle.RowId);
         }
 
+        /// <param name="handle">To be added.</param>
         public DeclarativeSecurityAttribute GetDeclarativeSecurityAttribute(DeclarativeSecurityAttributeHandle handle)
         {
             // PERF: This code pattern is JIT friendly and results in very efficient code.
             return new DeclarativeSecurityAttribute(this, handle.RowId);
         }
 
+        /// <param name="handle">To be added.</param>
         public Constant GetConstant(ConstantHandle handle)
         {
             return new Constant(this, handle.RowId);
         }
 
+        /// <param name="handle">To be added.</param>
         public MethodDefinition GetMethodDefinition(MethodDefinitionHandle handle)
         {
             // PERF: This code pattern is JIT friendly and results in very efficient code.
@@ -1221,6 +1247,7 @@ namespace System.Reflection.Metadata
             return CalculateMethodDefTreatmentAndRowId(handle);
         }
 
+        /// <param name="handle">To be added.</param>
         public FieldDefinition GetFieldDefinition(FieldDefinitionHandle handle)
         {
             // PERF: This code pattern is JIT friendly and results in very efficient code.
@@ -1238,21 +1265,25 @@ namespace System.Reflection.Metadata
             return CalculateFieldDefTreatmentAndRowId(handle);
         }
 
+        /// <param name="handle">To be added.</param>
         public PropertyDefinition GetPropertyDefinition(PropertyDefinitionHandle handle)
         {
             return new PropertyDefinition(this, handle);
         }
 
+        /// <param name="handle">To be added.</param>
         public EventDefinition GetEventDefinition(EventDefinitionHandle handle)
         {
             return new EventDefinition(this, handle);
         }
 
+        /// <param name="handle">To be added.</param>
         public MethodImplementation GetMethodImplementation(MethodImplementationHandle handle)
         {
             return new MethodImplementation(this, handle);
         }
 
+        /// <param name="handle">To be added.</param>
         public MemberReference GetMemberReference(MemberReferenceHandle handle)
         {
             // PERF: This code pattern is JIT friendly and results in very efficient code.
@@ -1270,51 +1301,61 @@ namespace System.Reflection.Metadata
             return CalculateMemberRefTreatmentAndRowId(handle);
         }
 
+        /// <param name="handle">To be added.</param>
         public MethodSpecification GetMethodSpecification(MethodSpecificationHandle handle)
         {
             return new MethodSpecification(this, handle);
         }
 
+        /// <param name="handle">To be added.</param>
         public Parameter GetParameter(ParameterHandle handle)
         {
             return new Parameter(this, handle);
         }
 
+        /// <param name="handle">To be added.</param>
         public GenericParameter GetGenericParameter(GenericParameterHandle handle)
         {
             return new GenericParameter(this, handle);
         }
 
+        /// <param name="handle">To be added.</param>
         public GenericParameterConstraint GetGenericParameterConstraint(GenericParameterConstraintHandle handle)
         {
             return new GenericParameterConstraint(this, handle);
         }
 
+        /// <param name="handle">To be added.</param>
         public ManifestResource GetManifestResource(ManifestResourceHandle handle)
         {
             return new ManifestResource(this, handle);
         }
 
+        /// <param name="handle">To be added.</param>
         public AssemblyFile GetAssemblyFile(AssemblyFileHandle handle)
         {
             return new AssemblyFile(this, handle);
         }
 
+        /// <param name="handle">To be added.</param>
         public StandaloneSignature GetStandaloneSignature(StandaloneSignatureHandle handle)
         {
             return new StandaloneSignature(this, handle);
         }
 
+        /// <param name="handle">To be added.</param>
         public TypeSpecification GetTypeSpecification(TypeSpecificationHandle handle)
         {
             return new TypeSpecification(this, handle);
         }
 
+        /// <param name="handle">To be added.</param>
         public ModuleReference GetModuleReference(ModuleReferenceHandle handle)
         {
             return new ModuleReference(this, handle);
         }
 
+        /// <param name="handle">To be added.</param>
         public InterfaceImplementation GetInterfaceImplementation(InterfaceImplementationHandle handle)
         {
             return new InterfaceImplementation(this, handle);
@@ -1370,61 +1411,73 @@ namespace System.Reflection.Metadata
             return PropertyMapTable.FindTypeContainingProperty(propertyDef.RowId, PropertyTable.NumberOfRows);
         }
 
+        /// <param name="handle">To be added.</param>
         public string GetString(DocumentNameBlobHandle handle)
         {
             return BlobHeap.GetDocumentName(handle);
         }
 
+        /// <param name="handle">To be added.</param>
         public Document GetDocument(DocumentHandle handle)
         {
             return new Document(this, handle);
         }
 
+        /// <param name="handle">To be added.</param>
         public MethodDebugInformation GetMethodDebugInformation(MethodDebugInformationHandle handle)
         {
             return new MethodDebugInformation(this, handle);
         }
 
+        /// <param name="handle">To be added.</param>
         public MethodDebugInformation GetMethodDebugInformation(MethodDefinitionHandle handle)
         {
             return new MethodDebugInformation(this, MethodDebugInformationHandle.FromRowId(handle.RowId));
         }
 
+        /// <param name="handle">To be added.</param>
         public LocalScope GetLocalScope(LocalScopeHandle handle)
         {
             return new LocalScope(this, handle);
         }
 
+        /// <param name="handle">To be added.</param>
         public LocalVariable GetLocalVariable(LocalVariableHandle handle)
         {
             return new LocalVariable(this, handle);
         }
 
+        /// <param name="handle">To be added.</param>
         public LocalConstant GetLocalConstant(LocalConstantHandle handle)
         {
             return new LocalConstant(this, handle);
         }
 
+        /// <param name="handle">To be added.</param>
         public ImportScope GetImportScope(ImportScopeHandle handle)
         {
             return new ImportScope(this, handle);
         }
 
+        /// <param name="handle">To be added.</param>
         public CustomDebugInformation GetCustomDebugInformation(CustomDebugInformationHandle handle)
         {
             return new CustomDebugInformation(this, handle);
         }
 
+        /// <param name="handle">To be added.</param>
         public CustomDebugInformationHandleCollection GetCustomDebugInformation(EntityHandle handle)
         {
             return new CustomDebugInformationHandleCollection(this, handle);
         }
 
+        /// <param name="handle">To be added.</param>
         public LocalScopeHandleCollection GetLocalScopes(MethodDefinitionHandle handle)
         {
             return new LocalScopeHandleCollection(this, handle.RowId);
         }
 
+        /// <param name="handle">To be added.</param>
         public LocalScopeHandleCollection GetLocalScopes(MethodDebugInformationHandle handle)
         {
             return new LocalScopeHandleCollection(this, handle.RowId);

--- a/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/MetadataReader.netstandard.cs
+++ b/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/MetadataReader.netstandard.cs
@@ -10,8 +10,31 @@ using Microsoft.Win32.SafeHandles;
 
 namespace System.Reflection.Metadata
 {
+    /// <summary>
+    /// Reads metadata as defined by the ECMA 335 CLI specification.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="System.Reflection.Metadata.MetadataReader"/> reads the contents of tables and heaps from the specified CLI metadata. It operates low-level constructs such as type and method definitions. For a higher level API to inspect the contents of assemblies using reflection constructs, see <see cref="System.Reflection.MetadataLoadContext"/>.
+    /// You can use constructors, such as <see cref="System.Reflection.Metadata.MetadataReader.#ctor(System.Byte,System.Int32)"/>, to create an instance of <see cref="System.Reflection.Metadata.MetadataReader"/> for a given memory location. To read metadata from the Portable Executable assembly file, create <see cref="System.Reflection.PortableExecutable.PEReader"/> and use the <see cref="System.Reflection.Metadata.PEReaderExtensions.GetMetadataReader(System.Reflection.PortableExecutable.PEReader)"/> extension method.
+    /// The format of CLI metadata is defined by the ECMA-335 specification. For more information, see [Standard ECMA-335 - Common Language Infrastructure (CLI)](https://www.ecma-international.org/publications-and-standards/standards/ecma-335/) on the Ecma International Web site.
+    /// This example shows how to create <see cref="System.Reflection.Metadata.MetadataReader"/> for an assembly and read all type definitions from it:
+    /// <code lang="csharp" source="~/snippets/csharp/System.Reflection.Metadata/MetadataReader/MetadataReaderSnippets.cs" id="SnippetMetadataReader" />
+    /// </remarks>
     public sealed partial class MetadataReader
     {
+        /// <summary>
+        /// Gets the <see cref="AssemblyName"/> for a given file.
+        /// </summary>
+        /// <param name="assemblyFile">The path for the assembly which <see cref="AssemblyName"/> is to be returned.</param>
+        /// <returns>An <see cref="AssemblyName"/> that represents the given <paramref name="assemblyFile"/>.</returns>
+        /// <exception cref="ArgumentNullException">If <paramref name="assemblyFile"/> is null.</exception>
+        /// <exception cref="ArgumentException">If <paramref name="assemblyFile"/> is invalid.</exception>
+        /// <exception cref="FileNotFoundException">If <paramref name="assemblyFile"/> is not found.</exception>
+        /// <exception cref="BadImageFormatException">If <paramref name="assemblyFile"/> is not a valid assembly.</exception>
+        /// <exception cref="T:System.ArgumentNullException"><paramref name="assemblyFile"/> is <see langword="null"/>.</exception>
+        /// <exception cref="T:System.ArgumentException"><paramref name="assemblyFile"/> is invalid.</exception>
+        /// <exception cref="T:System.IO.FileNotFoundException"><paramref name="assemblyFile"/> is not found.</exception>
+        /// <exception cref="T:System.BadImageFormatException"><paramref name="assemblyFile"/> is not a valid assembly.</exception>
         internal AssemblyName GetAssemblyName(StringHandle nameHandle, Version version, StringHandle cultureHandle, BlobHandle publicKeyOrTokenHandle, AssemblyHashAlgorithm assemblyHashAlgorithm, AssemblyFlags flags)
         {
             string name = GetString(nameHandle);

--- a/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/MetadataStringComparer.cs
+++ b/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/MetadataStringComparer.cs
@@ -55,11 +55,16 @@ namespace System.Reflection.Metadata
             _reader = reader;
         }
 
+        /// <param name="handle">To be added.</param>
+        /// <param name="value">To be added.</param>
         public bool Equals(StringHandle handle, string value)
         {
             return Equals(handle, value, ignoreCase: false);
         }
 
+        /// <param name="handle">To be added.</param>
+        /// <param name="value">To be added.</param>
+        /// <param name="ignoreCase">To be added.</param>
         public bool Equals(StringHandle handle, string value, bool ignoreCase)
         {
             ArgumentNullException.ThrowIfNull(value);
@@ -67,11 +72,16 @@ namespace System.Reflection.Metadata
             return _reader.StringHeap.Equals(handle, value, _reader.UTF8Decoder, ignoreCase);
         }
 
+        /// <param name="handle">To be added.</param>
+        /// <param name="value">To be added.</param>
         public bool Equals(NamespaceDefinitionHandle handle, string value)
         {
             return Equals(handle, value, ignoreCase: false);
         }
 
+        /// <param name="handle">To be added.</param>
+        /// <param name="value">To be added.</param>
+        /// <param name="ignoreCase">To be added.</param>
         public bool Equals(NamespaceDefinitionHandle handle, string value, bool ignoreCase)
         {
             ArgumentNullException.ThrowIfNull(value);
@@ -84,11 +94,16 @@ namespace System.Reflection.Metadata
             return value == _reader.NamespaceCache.GetFullName(handle);
         }
 
+        /// <param name="handle">To be added.</param>
+        /// <param name="value">To be added.</param>
         public bool Equals(DocumentNameBlobHandle handle, string value)
         {
             return Equals(handle, value, ignoreCase: false);
         }
 
+        /// <param name="handle">To be added.</param>
+        /// <param name="value">To be added.</param>
+        /// <param name="ignoreCase">To be added.</param>
         public bool Equals(DocumentNameBlobHandle handle, string value, bool ignoreCase)
         {
             ArgumentNullException.ThrowIfNull(value);
@@ -96,11 +111,16 @@ namespace System.Reflection.Metadata
             return _reader.BlobHeap.DocumentNameEquals(handle, value, ignoreCase);
         }
 
+        /// <param name="handle">To be added.</param>
+        /// <param name="value">To be added.</param>
         public bool StartsWith(StringHandle handle, string value)
         {
             return StartsWith(handle, value, ignoreCase: false);
         }
 
+        /// <param name="handle">To be added.</param>
+        /// <param name="value">To be added.</param>
+        /// <param name="ignoreCase">To be added.</param>
         public bool StartsWith(StringHandle handle, string value, bool ignoreCase)
         {
             ArgumentNullException.ThrowIfNull(value);

--- a/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/PortablePdb/DocumentNameBlobHandle.cs
+++ b/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/PortablePdb/DocumentNameBlobHandle.cs
@@ -54,11 +54,17 @@ namespace System.Reflection.Metadata
             get { return _heapOffset == 0; }
         }
 
+        /// <param name="obj">To be added.</param>
         public override bool Equals([NotNullWhen(true)] object? obj)
         {
             return obj is DocumentNameBlobHandle documentHandle && Equals(documentHandle);
         }
 
+        /// <summary>
+        /// Indicates whether the current object is equal to another object of the same type.
+        /// </summary>
+        /// <param name="other">An object to compare with this object.</param>
+        /// <returns><see langword="true"/> if the current object is equal to the <paramref name="other"/> parameter; otherwise, <see langword="false"/>.</returns>
         public bool Equals(DocumentNameBlobHandle other)
         {
             return _heapOffset == other._heapOffset;
@@ -69,11 +75,15 @@ namespace System.Reflection.Metadata
             return _heapOffset;
         }
 
+        /// <param name="left">To be added.</param>
+        /// <param name="right">To be added.</param>
         public static bool operator ==(DocumentNameBlobHandle left, DocumentNameBlobHandle right)
         {
             return left.Equals(right);
         }
 
+        /// <param name="left">To be added.</param>
+        /// <param name="right">To be added.</param>
         public static bool operator !=(DocumentNameBlobHandle left, DocumentNameBlobHandle right)
         {
             return !left.Equals(right);

--- a/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/PortablePdb/Handles.Debug.cs
+++ b/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/PortablePdb/Handles.Debug.cs
@@ -147,16 +147,24 @@ namespace System.Reflection.Metadata
 
         internal int RowId { get { return _rowId; } }
 
+        /// <param name="left">To be added.</param>
+        /// <param name="right">To be added.</param>
         public static bool operator ==(MethodDebugInformationHandle left, MethodDebugInformationHandle right)
         {
             return left._rowId == right._rowId;
         }
 
+        /// <param name="obj">To be added.</param>
         public override bool Equals(object? obj)
         {
             return obj is MethodDebugInformationHandle mdih && mdih._rowId == _rowId;
         }
 
+        /// <summary>
+        /// Indicates whether the current object is equal to another object of the same type.
+        /// </summary>
+        /// <param name="other">An object to compare with this object.</param>
+        /// <returns><see langword="true"/> if the current object is equal to the <paramref name="other"/> parameter; otherwise, <see langword="false"/>.</returns>
         public bool Equals(MethodDebugInformationHandle other)
         {
             return _rowId == other._rowId;
@@ -167,6 +175,8 @@ namespace System.Reflection.Metadata
             return _rowId.GetHashCode();
         }
 
+        /// <param name="left">To be added.</param>
+        /// <param name="right">To be added.</param>
         public static bool operator !=(MethodDebugInformationHandle left, MethodDebugInformationHandle right)
         {
             return left._rowId != right._rowId;

--- a/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/Signatures/ArrayShape.cs
+++ b/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/Signatures/ArrayShape.cs
@@ -25,6 +25,12 @@ namespace System.Reflection.Metadata
         /// </summary>
         public ImmutableArray<int> LowerBounds { get; }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="T:System.Reflection.Metadata.ArrayShape"/> structure.
+        /// </summary>
+        /// <param name="rank">The number of dimensions in the array.</param>
+        /// <param name="sizes">The size of each dimension.</param>
+        /// <param name="lowerBounds">The lower-bound of each dimension.</param>
         public ArrayShape(int rank, ImmutableArray<int> sizes, ImmutableArray<int> lowerBounds)
         {
             Rank = rank;

--- a/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/Signatures/SignatureHeader.cs
+++ b/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/Signatures/SignatureHeader.cs
@@ -16,24 +16,45 @@ namespace System.Reflection.Metadata
     public struct SignatureHeader : IEquatable<SignatureHeader>
     {
         private readonly byte _rawValue;
+        /// <summary>
+        /// Gets the mask value for the calling convention or signature kind. The default <see cref="F:System.Reflection.Metadata.SignatureHeader.CallingConventionOrKindMask"/> value is 15 (0x0F).
+        /// </summary>
         public const byte CallingConventionOrKindMask = 0x0F;
         private const byte maxCallingConvention = (byte)SignatureCallingConvention.VarArgs;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="T:System.Reflection.Metadata.SignatureHeader"/> structure using the specified byte value.
+        /// </summary>
+        /// <param name="rawValue">The byte.</param>
         public SignatureHeader(byte rawValue)
         {
             _rawValue = rawValue;
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="T:System.Reflection.Metadata.SignatureHeader"/> structure using the specified signature kind, calling convention and signature attributes.
+        /// </summary>
+        /// <param name="kind">The signature kind.</param>
+        /// <param name="convention">The calling convention.</param>
+        /// <param name="attributes">The signature attributes.</param>
         public SignatureHeader(SignatureKind kind, SignatureCallingConvention convention, SignatureAttributes attributes)
              : this((byte)((int)kind | (int)convention | (int)attributes))
         {
         }
 
+        /// <summary>
+        /// Gets the raw value of the header byte.
+        /// </summary>
+        /// <value>The raw value of the header byte.</value>
         public byte RawValue
         {
             get { return _rawValue; }
         }
 
+        /// <summary>
+        /// Gets the calling convention.
+        /// </summary>
+        /// <value>The calling convention.</value>
         public SignatureCallingConvention CallingConvention
         {
             get
@@ -50,6 +71,10 @@ namespace System.Reflection.Metadata
             }
         }
 
+        /// <summary>
+        /// Gets the signature kind.
+        /// </summary>
+        /// <value>The signature kind.</value>
         public SignatureKind Kind
         {
             get
@@ -66,51 +91,97 @@ namespace System.Reflection.Metadata
             }
         }
 
+        /// <summary>
+        /// Gets the signature attributes.
+        /// </summary>
+        /// <value>The attributes.</value>
         public SignatureAttributes Attributes
         {
             get { return (SignatureAttributes)(_rawValue & ~CallingConventionOrKindMask); }
         }
 
+        /// <summary>
+        /// Gets a value that indicates whether this <see cref="T:System.Reflection.Metadata.SignatureHeader"/> structure has the <see cref="F:System.Reflection.Metadata.SignatureAttributes.ExplicitThis"/> signature attribute.
+        /// </summary>
+        /// <value><see langword="true"/> if the <see cref="F:System.Reflection.Metadata.SignatureAttributes.ExplicitThis"/> attribute is present; otherwise, <see langword="false"/>.</value>
         public bool HasExplicitThis
         {
             get { return (_rawValue & (byte)SignatureAttributes.ExplicitThis) != 0; }
         }
 
+        /// <summary>
+        /// Gets a value that indicates whether this <see cref="T:System.Reflection.Metadata.SignatureHeader"/> structure has the <see cref="F:System.Reflection.Metadata.SignatureAttributes.Instance"/> signature attribute.
+        /// </summary>
+        /// <value><see langword="true"/> if the <see cref="F:System.Reflection.Metadata.SignatureAttributes.Instance"/> attribute is present; otherwise, <see langword="false"/>.</value>
         public bool IsInstance
         {
             get { return (_rawValue & (byte)SignatureAttributes.Instance) != 0; }
         }
 
+        /// <summary>
+        /// Gets a value that indicates whether this <see cref="T:System.Reflection.Metadata.SignatureHeader"/> structure has the <see cref="F:System.Reflection.Metadata.SignatureAttributes.Generic"/> signature attribute.
+        /// </summary>
+        /// <value><see langword="true"/> if the <see cref="F:System.Reflection.Metadata.SignatureAttributes.Generic"/> attribute is present; otherwise, <see langword="false"/>.</value>
         public bool IsGeneric
         {
             get { return (_rawValue & (byte)SignatureAttributes.Generic) != 0; }
         }
 
+        /// <summary>
+        /// Compares the specified object with this <see cref="T:System.Reflection.Metadata.SignatureHeader"/> for equality.
+        /// </summary>
+        /// <param name="obj">The object to compare.</param>
+        /// <returns><see langword="true"/> if the objects are equal; otherwise, <see langword="false"/>.</returns>
         public override bool Equals([NotNullWhen(true)] object? obj)
         {
             return obj is SignatureHeader signatureHeader && Equals(signatureHeader);
         }
 
+        /// <summary>
+        /// Compares two <see cref="T:System.Reflection.Metadata.SignatureHeader"/> values for equality.
+        /// </summary>
+        /// <param name="other">The value to compare.</param>
+        /// <returns><see langword="true"/> if the values are equal; otherwise, <see langword="false"/>.</returns>
         public bool Equals(SignatureHeader other)
         {
             return _rawValue == other._rawValue;
         }
 
+        /// <summary>
+        /// Gets a hash code for the current object.
+        /// </summary>
+        /// <returns>A hash code for the current object.</returns>
         public override int GetHashCode()
         {
             return _rawValue;
         }
 
+        /// <summary>
+        /// Compares two <see cref="T:System.Reflection.Metadata.SignatureHeader"/> values for equality.
+        /// </summary>
+        /// <param name="left">The first value to compare.</param>
+        /// <param name="right">The second value to compare.</param>
+        /// <returns><see langword="true"/> if the values are equal; otherwise, <see langword="false"/>.</returns>
         public static bool operator ==(SignatureHeader left, SignatureHeader right)
         {
             return left._rawValue == right._rawValue;
         }
 
+        /// <summary>
+        /// Determines whether two <see cref="T:System.Reflection.Metadata.SignatureHeader"/> values are unequal.
+        /// </summary>
+        /// <param name="left">The first value to compare.</param>
+        /// <param name="right">The second value to compare.</param>
+        /// <returns><see langword="true"/> if the values are unequal; otherwise, <see langword="false"/>.</returns>
         public static bool operator !=(SignatureHeader left, SignatureHeader right)
         {
             return left._rawValue != right._rawValue;
         }
 
+        /// <summary>
+        /// Returns a string that represents the current object.
+        /// </summary>
+        /// <returns>A string that represents the current object.</returns>
         public override string ToString()
         {
             var sb = new StringBuilder();

--- a/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/TypeSystem/CustomAttribute.cs
+++ b/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/TypeSystem/CustomAttribute.cs
@@ -6,6 +6,14 @@ using System.Reflection.Metadata.Ecma335;
 
 namespace System.Reflection.Metadata
 {
+    /// <summary>
+    /// Provides information about a custom attribute.
+    /// </summary>
+    /// <remarks>
+    /// A custom attribute is an annotation that associates additional information with a metadata element, such as an assembly, type, or method. You can use the <see cref="System.Reflection.Metadata.MetadataReader.GetCustomAttribute(System.Reflection.Metadata.CustomAttributeHandle)"/> method to get a custom attribute instance. For more information about attributes in .NET, see [Extend metadata using attributes](/dotnet/standard/attributes/).
+    /// This example shows how to print all custom attributes applied to the type definition:
+    /// <code lang="csharp" source="~/snippets/csharp/System.Reflection.Metadata/CustomAttribute/Overview/CustomAttributeSnippets.cs" id="SnippetPrintAttributes" />
+    /// </remarks>
     public readonly struct CustomAttribute
     {
         private readonly MetadataReader _reader;

--- a/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/TypeSystem/HandleCollections.TypeSystem.cs
+++ b/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/TypeSystem/HandleCollections.TypeSystem.cs
@@ -23,6 +23,10 @@ namespace System.Reflection.Metadata
             _count = count;
         }
 
+        /// <summary>
+        /// Gets the number of elements in the collection.
+        /// </summary>
+        /// <value>The number of elements in the collection.</value>
         public int Count
         {
             get
@@ -31,6 +35,11 @@ namespace System.Reflection.Metadata
             }
         }
 
+        /// <summary>
+        /// Gets the element at the specified index in the read-only list.
+        /// </summary>
+        /// <param name="index">The zero-based index of the element to get.</param>
+        /// <value>The element at the specified index in the read-only list.</value>
         public GenericParameterHandle this[int index]
         {
             get

--- a/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/TypeSystem/Handles.TypeSystem.cs
+++ b/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/TypeSystem/Handles.TypeSystem.cs
@@ -256,6 +256,9 @@ namespace System.Reflection.Metadata
         }
     }
 
+    /// <summary>
+    /// Provides a handle to a namespace definition.
+    /// </summary>
     public readonly struct MethodDefinitionHandle : IEquatable<MethodDefinitionHandle>
     {
         private const uint tokenType = TokenTypeIds.MethodDef;
@@ -313,16 +316,20 @@ namespace System.Reflection.Metadata
 
         internal int RowId { get { return _rowId; } }
 
+        /// <param name="left">To be added.</param>
+        /// <param name="right">To be added.</param>
         public static bool operator ==(MethodDefinitionHandle left, MethodDefinitionHandle right)
         {
             return left._rowId == right._rowId;
         }
 
+        /// <param name="obj">To be added.</param>
         public override bool Equals(object? obj)
         {
             return obj is MethodDefinitionHandle && ((MethodDefinitionHandle)obj)._rowId == _rowId;
         }
 
+        /// <param name="obj">To be added.</param>
         public bool Equals(MethodDefinitionHandle other)
         {
             return _rowId == other._rowId;
@@ -333,6 +340,8 @@ namespace System.Reflection.Metadata
             return _rowId.GetHashCode();
         }
 
+        /// <param name="left">To be added.</param>
+        /// <param name="right">To be added.</param>
         public static bool operator !=(MethodDefinitionHandle left, MethodDefinitionHandle right)
         {
             return left._rowId != right._rowId;


### PR DESCRIPTION
Doc-only migration for `System.Reflection.Metadata` — 192 types, 19 files modified, +415 lines. Generated by [`slash merge --mode fill-gaps`](https://github.com/richlander/slash-slash-slash-ftw). See [richlander/runtime#1](https://github.com/richlander/runtime/pull/1) for full context on the approach, tooling, and design goals.

### Quality: before → after

|  | `main` | This branch | Delta |
|--|--------|-------------|-------|
| **Types** | 178/192 Good (92.7%) | 178/192 Good (92.7%) | — |
| **Members: Good** | 1,310/1,738 (75.4%) | 1,331/1,782 (74.7%) | +21 |
| **Members: None** | 15 (0.9%) | 38 (2.1%) | +23 new members discovered |
| **Conflicts: Significant** | 113 | 113 | — |
| **Conflicts: Cosmetic** | 77 | 78 | +1 |
| **Samples** | 0 | 0 | — |

The member count increased from 1,738 to 1,782 because `fill-gaps` adds `///` comments to members that previously had no C# docs, making them visible to the quality analyzer. The 21 newly-Good members are gaps that were filled from `dotnet-api-docs` XML.

This is a doc-only migration — no samples were added. Samples would be a follow-up pass using the LLM agent fleet workflow described in [PR #1](https://github.com/richlander/runtime/pull/1).

> **Note:** This PR is for review and discussion — not intended for merge.
