### PR TITLE
System.Collections.Immutable: migrate XML docs (fill-gaps)

### DIFF
--- a/src/libraries/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray_1.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray_1.cs
@@ -11,6 +11,10 @@ using System.Runtime.Versioning;
 
 namespace System.Collections.Immutable
 {
+    /// <summary>
+    /// Provides methods for creating an array that is immutable; meaning it cannot be changed once it is created.
+    /// **NuGet package**: <see href="https://www.nuget.org/packages/System.Collections.Immutable/">System.Collections.Immutable</see> (<see href="https://learn.microsoft.com/dotnet/api/system.collections.immutable?#remarks">about immutable collections and how to install</see>)
+    /// </summary>
     [CollectionBuilder(typeof(ImmutableArray), nameof(ImmutableArray.Create))]
     public readonly partial struct ImmutableArray<T> : IReadOnlyList<T>, IList<T>, IEquatable<ImmutableArray<T>>, IList, IImmutableArray, IStructuralComparable, IStructuralEquatable, IImmutableList<T>
     {
@@ -1040,26 +1044,51 @@ namespace System.Collections.Immutable
 
         #region Explicit interface methods
 
+        /// <summary>
+        /// Returns a new array with the specified value inserted at the specified position.
+        /// </summary>
+        /// <param name="index">The 0-based index into the array at which the new item should be added.</param>
+        /// <param name="item">The item to insert at the start of the array.</param>
+        /// <returns>A new array.</returns>
         void IList<T>.Insert(int index, T item)
         {
             throw new NotSupportedException();
         }
 
+        /// <summary>
+        /// Returns an array with the element at the specified position removed.
+        /// </summary>
+        /// <param name="index">The 0-based index into the array for the element to omit from the returned array.</param>
+        /// <returns>The new array.</returns>
         void IList<T>.RemoveAt(int index)
         {
             throw new NotSupportedException();
         }
 
+        /// <summary>
+        /// Returns a new array with the specified value inserted at the end.
+        /// </summary>
+        /// <param name="item">The item to insert at the end of the array.</param>
+        /// <returns>A new array.</returns>
         void ICollection<T>.Add(T item)
         {
             throw new NotSupportedException();
         }
 
+        /// <summary>
+        /// Returns an empty array.
+        /// </summary>
         void ICollection<T>.Clear()
         {
             throw new NotSupportedException();
         }
 
+        /// <summary>
+        /// Returns an array with the first occurrence of the specified element removed from the array.
+        /// If no match is found, the current array is returned.
+        /// </summary>
+        /// <param name="item">The item to remove.</param>
+        /// <returns>The new array.</returns>
         bool ICollection<T>.Remove(T item)
         {
             throw new NotSupportedException();

--- a/src/libraries/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray_1.netcoreapp.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray_1.netcoreapp.cs
@@ -5,6 +5,10 @@ using System.Collections.Generic;
 
 namespace System.Collections.Immutable
 {
+    /// <summary>
+    /// Provides methods for creating an array that is immutable; meaning it cannot be changed once it is created.
+    /// **NuGet package**: <see href="https://www.nuget.org/packages/System.Collections.Immutable/">System.Collections.Immutable</see> (<see href="https://learn.microsoft.com/dotnet/api/system.collections.immutable?#remarks">about immutable collections and how to install</see>)
+    /// </summary>
     public readonly partial struct ImmutableArray<T> : IReadOnlyList<T>, IList<T>, IEquatable<ImmutableArray<T>>, IList, IImmutableArray, IStructuralComparable, IStructuralEquatable, IImmutableList<T>
     {
         /// <summary>

--- a/src/libraries/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableDictionary_2.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableDictionary_2.cs
@@ -268,6 +268,10 @@ namespace System.Collections.Immutable
 
         #region ICollection<KeyValuePair<TKey, TValue>> Properties
 
+        /// <summary>
+        /// Gets a value indicating whether the <see cref="ICollection{T}"/> is read-only.
+        /// </summary>
+        /// <returns>true if the <see cref="ICollection{T}"/> is read-only; otherwise, false. </returns>
         bool ICollection<KeyValuePair<TKey, TValue>>.IsReadOnly
         {
             get { return true; }
@@ -315,6 +319,9 @@ namespace System.Collections.Immutable
             return this.AddRange(pairs, false);
         }
 
+        /// <summary>
+        /// See the <see cref="IImmutableDictionary{TKey, TValue}"/> interface.
+        /// </summary>
         internal ImmutableDictionary<TKey, TValue> AddRange(ReadOnlySpan<KeyValuePair<TKey, TValue>> pairs, KeyCollisionBehavior collisionBehavior = KeyCollisionBehavior.ThrowIfValueDifferent)
         {
             return AddRange(pairs, this.Origin, collisionBehavior).Finalize(this);
@@ -598,21 +605,35 @@ namespace System.Collections.Immutable
 
         #region ICollection<KeyValuePair<TKey, TValue>> Methods
 
+        /// <summary>
+        /// See the <see cref="IImmutableDictionary{TKey, TValue}"/> interface.
+        /// </summary>
         void ICollection<KeyValuePair<TKey, TValue>>.Add(KeyValuePair<TKey, TValue> item)
         {
             throw new NotSupportedException();
         }
 
+        /// <summary>
+        /// See the <see cref="IImmutableDictionary{TKey, TValue}"/> interface.
+        /// </summary>
         void ICollection<KeyValuePair<TKey, TValue>>.Clear()
         {
             throw new NotSupportedException();
         }
 
+        /// <summary>
+        /// See the <see cref="IImmutableDictionary{TKey, TValue}"/> interface.
+        /// </summary>
         bool ICollection<KeyValuePair<TKey, TValue>>.Remove(KeyValuePair<TKey, TValue> item)
         {
             throw new NotSupportedException();
         }
 
+        /// <summary>
+        /// Copies the elements of the <see cref="ICollection"/> to an <see cref="Array"/>, starting at a particular <see cref="Array"/> index.
+        /// </summary>
+        /// <param name="array">The one-dimensional <see cref="Array"/> that is the destination of the elements copied from <see cref="ICollection"/>. The <see cref="Array"/> must have zero-based indexing.</param>
+        /// <param name="arrayIndex">The zero-based index in <paramref name="array"/> at which copying begins.</param>
         void ICollection<KeyValuePair<TKey, TValue>>.CopyTo(KeyValuePair<TKey, TValue>[] array, int arrayIndex)
         {
             Requires.NotNull(array, nameof(array));

--- a/src/libraries/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableSortedDictionary_2.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableSortedDictionary_2.cs
@@ -158,6 +158,10 @@ namespace System.Collections.Immutable
 
         #region ICollection<KeyValuePair<TKey, TValue>> Properties
 
+        /// <summary>
+        /// Gets a value indicating whether the <see cref="ICollection{T}"/> is read-only.
+        /// </summary>
+        /// <returns>true if the <see cref="ICollection{T}"/> is read-only; otherwise, false. </returns>
         bool ICollection<KeyValuePair<TKey, TValue>>.IsReadOnly
         {
             get { return true; }
@@ -503,21 +507,35 @@ namespace System.Collections.Immutable
 
         #region ICollection<KeyValuePair<TKey, TValue>> Methods
 
+        /// <summary>
+        /// See the <see cref="IImmutableDictionary{TKey, TValue}"/> interface.
+        /// </summary>
         void ICollection<KeyValuePair<TKey, TValue>>.Add(KeyValuePair<TKey, TValue> item)
         {
             throw new NotSupportedException();
         }
 
+        /// <summary>
+        /// See the <see cref="IImmutableDictionary{TKey, TValue}"/> interface.
+        /// </summary>
         void ICollection<KeyValuePair<TKey, TValue>>.Clear()
         {
             throw new NotSupportedException();
         }
 
+        /// <summary>
+        /// See the <see cref="IImmutableDictionary{TKey, TValue}"/> interface.
+        /// </summary>
         bool ICollection<KeyValuePair<TKey, TValue>>.Remove(KeyValuePair<TKey, TValue> item)
         {
             throw new NotSupportedException();
         }
 
+        /// <summary>
+        /// Copies the elements of the <see cref="ICollection"/> to an <see cref="Array"/>, starting at a particular <see cref="Array"/> index.
+        /// </summary>
+        /// <param name="array">The one-dimensional <see cref="Array"/> that is the destination of the elements copied from <see cref="ICollection"/>. The <see cref="Array"/> must have zero-based indexing.</param>
+        /// <param name="index">The zero-based index in <paramref name="array"/> at which copying begins.</param>
         void ICollection<KeyValuePair<TKey, TValue>>.CopyTo(KeyValuePair<TKey, TValue>[] array, int arrayIndex)
         {
             Requires.NotNull(array, nameof(array));


### PR DESCRIPTION
Doc-only migration for `System.Collections.Immutable` — 36 types, 4 files modified, +72 lines. Generated by [`slash merge --mode fill-gaps`](https://github.com/richlander/slash-slash-slash-ftw). See [richlander/runtime#1](https://github.com/richlander/runtime/pull/1) for full context on the approach, tooling, and design goals.

### Quality: before → after

|  | `main` | This branch | Delta |
|--|--------|-------------|-------|
| **Types** | 36/36 Good (100%) | 36/36 Good (100%) | — |
| **Members: Good** | 1,000/1,011 (98.9%) | 1,000/1,011 (98.9%) | — |
| **Members: Low** | 11 (1.1%) | 11 (1.1%) | — |
| **Members: None** | 0 | 0 | — |
| **Conflicts: Significant** | 3 | 3 | — |
| **Conflicts: Cosmetic** | 5 | 5 | — |
| **Samples** | 0 | 0 | — |

This library is already exceptionally well-documented — 98.9% of members are Good quality. The migration filled a small number of gaps in `ImmutableArray<T>`, `ImmutableDictionary<TKey,TValue>`, and `ImmutableSortedDictionary<TKey,TValue>` where the C# source was missing `///` content that existed in `dotnet-api-docs`.

The 3 significant conflicts and 11 Low members remain as-is under `fill-gaps` mode (which only adds docs where C# has none). Resolving those would require `prefer-xml` mode or manual review.

This is a doc-only migration — no samples were added. This library would be a good candidate for samples given its widespread usage.

> **Note:** This PR is for review and discussion — not intended for merge.
