### PR TITLE
System.Collections.Immutable: migrate XML docs (fill-gaps)

### DIFF
--- a/src/libraries/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray_1.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray_1.cs
@@ -11,6 +11,10 @@ using System.Runtime.Versioning;
 
 namespace System.Collections.Immutable
 {
+    /// <summary>
+    /// Provides methods for creating an array that is immutable; meaning it cannot be changed once it is created.
+    /// **NuGet package**: <see href="https://www.nuget.org/packages/System.Collections.Immutable/">System.Collections.Immutable</see> (<see href="https://learn.microsoft.com/dotnet/api/system.collections.immutable?#remarks">about immutable collections and how to install</see>)
+    /// </summary>
     [CollectionBuilder(typeof(ImmutableArray), nameof(ImmutableArray.Create))]
     public readonly partial struct ImmutableArray<T> : IReadOnlyList<T>, IList<T>, IEquatable<ImmutableArray<T>>, IList, IImmutableArray, IStructuralComparable, IStructuralEquatable, IImmutableList<T>
     {

--- a/src/libraries/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray_1.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray_1.cs
@@ -12,9 +12,31 @@ using System.Runtime.Versioning;
 namespace System.Collections.Immutable
 {
     /// <summary>
-    /// Provides methods for creating an array that is immutable; meaning it cannot be changed once it is created.
+    /// Represents an array that is immutable; meaning it cannot be changed once it is created.
     /// **NuGet package**: <see href="https://www.nuget.org/packages/System.Collections.Immutable/">System.Collections.Immutable</see> (<see href="https://learn.microsoft.com/dotnet/api/system.collections.immutable?#remarks">about immutable collections and how to install</see>)
     /// </summary>
+    /// <typeparam name="T">The type of element stored by the array.</typeparam>
+    /// <remarks>
+    /// There are different scenarios best for <see cref="System.Collections.Immutable.ImmutableArray{T}"/> and others best for <see cref="System.Collections.Immutable.ImmutableList{T}"/>.
+    /// Reasons to use immutable array:
+    /// - Updating the data is rare or the number of elements is quite small (less than 16 items)
+    /// - You need to be able to iterate over the data in performance critical sections
+    /// - You have many instances of immutable collections and you can't afford keeping the data in trees
+    /// Reasons to use immutable list:
+    /// - Updating the data is common or the number of elements isn't expected to be small
+    /// - Updating the collection is more performance critical than iterating the contents
+    /// The following table summarizes the performance characteristics of <see cref="System.Collections.Immutable.ImmutableArray{T}"/>
+    /// | Operation | ImmutableArray complexity | ImmutableList complexity | Comments |
+    /// | --------- | ------------------------- | ------------------------ | -------- |
+    /// | <c>Item</c>    | O(1)                      | O(log n)                 | Directly index into the underlying array |
+    /// | <c>Add()</c>   | O(n)                      | O(log n)                 | Requires creating a new array |
+    /// This example shows how to create an immutable array and iterate over elements in it:
+    /// <code lang="csharp" source="~/snippets/csharp/System.Collections.Immutable/ImmutableArray`1/Overview/ImmutableArraySnippets.cs" id="SnippetIterate" />
+    /// This example shows how to create a new immutable array by adding and removing items from the original array:
+    /// <code lang="csharp" source="~/snippets/csharp/System.Collections.Immutable/ImmutableArray`1/Overview/ImmutableArraySnippets.cs" id="SnippetModify" />
+    /// This example shows how to create an immutable array using <see cref="System.Collections.Immutable.ImmutableArray{T}.Builder"/>:
+    /// <code lang="csharp" source="~/snippets/csharp/System.Collections.Immutable/ImmutableArray`1/Overview/ImmutableArraySnippets.cs" id="SnippetBuilder" />
+    /// </remarks>
     [CollectionBuilder(typeof(ImmutableArray), nameof(ImmutableArray.Create))]
     public readonly partial struct ImmutableArray<T> : IReadOnlyList<T>, IList<T>, IEquatable<ImmutableArray<T>>, IList, IImmutableArray, IStructuralComparable, IStructuralEquatable, IImmutableList<T>
     {
@@ -1044,26 +1066,59 @@ namespace System.Collections.Immutable
 
         #region Explicit interface methods
 
+        /// <summary>
+        /// Throws <see cref="T:System.NotSupportedException"/> in all cases.
+        /// </summary>
+        /// <param name="index">The index of the location to insert the item.</param>
+        /// <param name="item">The item to insert.</param>
+        /// <remarks>
+        /// This member is an explicit interface member implementation. It can be used only when the <see cref="System.Collections.Immutable.ImmutableArray{T}"/> instance is cast to an <see cref="System.Collections.Generic.IList{T}"/> interface.
+        /// </remarks>
         void IList<T>.Insert(int index, T item)
         {
             throw new NotSupportedException();
         }
 
+        /// <summary>
+        /// Throws <see cref="T:System.NotSupportedException"/> in all cases.
+        /// </summary>
+        /// <param name="index">The index.</param>
         void IList<T>.RemoveAt(int index)
         {
             throw new NotSupportedException();
         }
 
+        /// <summary>
+        /// Throws <see cref="T:System.NotSupportedException"/> in all cases.
+        /// </summary>
+        /// <param name="item">The item to add to the end of the array.</param>
+        /// <remarks>
+        /// This member is an explicit interface member implementation. It can be used only when the <see cref="System.Collections.Immutable.ImmutableArray{T}"/> instance is cast to an <see cref="System.Collections.Generic.ICollection{T}"/> interface.
+        /// </remarks>
         void ICollection<T>.Add(T item)
         {
             throw new NotSupportedException();
         }
 
+        /// <summary>
+        /// Throws <see cref="T:System.NotSupportedException"/> in all cases.
+        /// </summary>
+        /// <remarks>
+        /// This member is an explicit interface member implementation. It can be used only when the <see cref="System.Collections.Immutable.ImmutableArray{T}"/> instance is cast to an <see cref="System.Collections.Generic.ICollection{T}"/> interface.
+        /// </remarks>
         void ICollection<T>.Clear()
         {
             throw new NotSupportedException();
         }
 
+        /// <summary>
+        /// Throws <see cref="T:System.NotSupportedException"/> in all cases.
+        /// </summary>
+        /// <param name="item">The object to remove from the array.</param>
+        /// <returns>Throws <see cref="T:System.NotSupportedException"/> in all cases.</returns>
+        /// <remarks>
+        /// This member is an explicit interface member implementation. It can be used only when the <see cref="System.Collections.Immutable.ImmutableArray{T}"/> instance is cast to an <see cref="System.Collections.Generic.ICollection{T}"/> interface.
+        /// </remarks>
         bool ICollection<T>.Remove(T item)
         {
             throw new NotSupportedException();

--- a/src/libraries/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray_1.netcoreapp.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray_1.netcoreapp.cs
@@ -6,9 +6,31 @@ using System.Collections.Generic;
 namespace System.Collections.Immutable
 {
     /// <summary>
-    /// Provides methods for creating an array that is immutable; meaning it cannot be changed once it is created.
+    /// Represents an array that is immutable; meaning it cannot be changed once it is created.
     /// **NuGet package**: <see href="https://www.nuget.org/packages/System.Collections.Immutable/">System.Collections.Immutable</see> (<see href="https://learn.microsoft.com/dotnet/api/system.collections.immutable?#remarks">about immutable collections and how to install</see>)
     /// </summary>
+    /// <typeparam name="T">The type of element stored by the array.</typeparam>
+    /// <remarks>
+    /// There are different scenarios best for <see cref="System.Collections.Immutable.ImmutableArray{T}"/> and others best for <see cref="System.Collections.Immutable.ImmutableList{T}"/>.
+    /// Reasons to use immutable array:
+    /// - Updating the data is rare or the number of elements is quite small (less than 16 items)
+    /// - You need to be able to iterate over the data in performance critical sections
+    /// - You have many instances of immutable collections and you can't afford keeping the data in trees
+    /// Reasons to use immutable list:
+    /// - Updating the data is common or the number of elements isn't expected to be small
+    /// - Updating the collection is more performance critical than iterating the contents
+    /// The following table summarizes the performance characteristics of <see cref="System.Collections.Immutable.ImmutableArray{T}"/>
+    /// | Operation | ImmutableArray complexity | ImmutableList complexity | Comments |
+    /// | --------- | ------------------------- | ------------------------ | -------- |
+    /// | <c>Item</c>    | O(1)                      | O(log n)                 | Directly index into the underlying array |
+    /// | <c>Add()</c>   | O(n)                      | O(log n)                 | Requires creating a new array |
+    /// This example shows how to create an immutable array and iterate over elements in it:
+    /// <code lang="csharp" source="~/snippets/csharp/System.Collections.Immutable/ImmutableArray`1/Overview/ImmutableArraySnippets.cs" id="SnippetIterate" />
+    /// This example shows how to create a new immutable array by adding and removing items from the original array:
+    /// <code lang="csharp" source="~/snippets/csharp/System.Collections.Immutable/ImmutableArray`1/Overview/ImmutableArraySnippets.cs" id="SnippetModify" />
+    /// This example shows how to create an immutable array using <see cref="System.Collections.Immutable.ImmutableArray{T}.Builder"/>:
+    /// <code lang="csharp" source="~/snippets/csharp/System.Collections.Immutable/ImmutableArray`1/Overview/ImmutableArraySnippets.cs" id="SnippetBuilder" />
+    /// </remarks>
     public readonly partial struct ImmutableArray<T> : IReadOnlyList<T>, IList<T>, IEquatable<ImmutableArray<T>>, IList, IImmutableArray, IStructuralComparable, IStructuralEquatable, IImmutableList<T>
     {
         /// <summary>

--- a/src/libraries/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray_1.netcoreapp.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray_1.netcoreapp.cs
@@ -5,6 +5,10 @@ using System.Collections.Generic;
 
 namespace System.Collections.Immutable
 {
+    /// <summary>
+    /// Provides methods for creating an array that is immutable; meaning it cannot be changed once it is created.
+    /// **NuGet package**: <see href="https://www.nuget.org/packages/System.Collections.Immutable/">System.Collections.Immutable</see> (<see href="https://learn.microsoft.com/dotnet/api/system.collections.immutable?#remarks">about immutable collections and how to install</see>)
+    /// </summary>
     public readonly partial struct ImmutableArray<T> : IReadOnlyList<T>, IList<T>, IEquatable<ImmutableArray<T>>, IList, IImmutableArray, IStructuralComparable, IStructuralEquatable, IImmutableList<T>
     {
         /// <summary>

--- a/src/libraries/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableDictionary_2.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableDictionary_2.cs
@@ -315,6 +315,9 @@ namespace System.Collections.Immutable
             return this.AddRange(pairs, false);
         }
 
+        /// <summary>
+        /// See the <see cref="IImmutableDictionary{TKey, TValue}"/> interface.
+        /// </summary>
         internal ImmutableDictionary<TKey, TValue> AddRange(ReadOnlySpan<KeyValuePair<TKey, TValue>> pairs, KeyCollisionBehavior collisionBehavior = KeyCollisionBehavior.ThrowIfValueDifferent)
         {
             return AddRange(pairs, this.Origin, collisionBehavior).Finalize(this);


### PR DESCRIPTION
Doc-only migration for `System.Collections.Immutable` — 36 types, 3 files modified, +11 lines. Generated by [`slash merge --mode fill-gaps`](https://github.com/richlander/slash-slash-slash-ftw).

See [richlander/runtime#1](https://github.com/richlander/runtime/pull/1) for full context on the approach, tooling, and design goals.

### What changed vs [PR #3](https://github.com/richlander/runtime/pull/3)

Fixed a bug in the tool where explicit interface implementations (EII) were confused with regular methods. Previously `void IList<T>.Insert()` got docs from `ImmutableArray<T>.Insert()` (wrong return type, wrong semantics). Now EII members are correctly distinguished and left undocumented when no matching XML docs exist.

### Changes

- **ImmutableArray_1.cs** / **ImmutableArray_1.netcoreapp.cs**: Added type-level summary (partial class, both files)
- **ImmutableDictionary_2.cs**: Added summary to `internal AddRange` overload (matches existing pattern in surrounding code)

### Quality: before → after

|  | `main` | This branch | Delta |
|--|--------|-------------|-------|
| **Types** | 36/36 Good (100%) | 36/36 Good (100%) | — |
| **Members: Good** | 1,000/1,011 (98.9%) | 1,000/1,011 (98.9%) | — |

This library is already exceptionally well-documented. The migration filled a small number of genuine gaps where the C# source was missing `///` content that existed in `dotnet-api-docs`.

> **Note:** This PR is for review and discussion — not intended for merge.